### PR TITLE
Use existing CoreUsers from database for Seed - CU-803

### DIFF
--- a/workflow/seeds/admin.py
+++ b/workflow/seeds/admin.py
@@ -63,9 +63,8 @@ class OrganizationAdmin(admin.ModelAdmin):
         # Seed bifrost data
         seed_bifrost = SeedBifrost(organization,
                                    data.workflowleveltypes,
-                                   data.workflowlevel2s,
-                                   data.core_users)
-        level1_uuid, wfl2_uuid_map, core_user_uuid_map = seed_bifrost.seed()
+                                   data.workflowlevel2s)
+        level1_uuid, wfl2_uuid_map, org_core_user_uuids = seed_bifrost.seed()
 
         # Seed profiletypes and build profiletype_map
         profiletype_map = seed_env.get_profile_types_map(data.profiletypes)
@@ -78,8 +77,8 @@ class OrganizationAdmin(admin.ModelAdmin):
             "workflowlevel1": {"49a4c9d7-8b72-434b-8a48-24540f65a2f3": level1_uuid},
             "workflowlevel2": wfl2_uuid_map,
             "profiletypes": profiletype_map,
-            "coreusers": core_user_uuid_map,
             "categories": product_category_map,
+            "org_core_user_uuids": org_core_user_uuids,
         }
         seed = SeedLogicModule(seed_env, data.SEED_DATA)
         seed.seed()

--- a/workflow/seeds/data.py
+++ b/workflow/seeds/data.py
@@ -776,9 +776,11 @@ SEED_DATA = {
                 "contact_uuid": "contact",
                 "siteprofile_uuid": "siteprofiles",
                 "workflowlevel2_uuids": "workflowlevel2",
-                "invitee_uuids": "coreusers",
             },
             "update_dates": {"start_date": 20, "end_date": 20},
+            "set_fields": {
+                "invitee_uuids": "org_core_user_uuids",
+            }
         },
     },
     "products": {
@@ -798,10 +800,12 @@ SEED_DATA = {
             "validate": False,
             "data": time_events,
             "update_fields": {
-                "core_user_uuid": "coreusers",
                 "workflowlevel2_uuid": "workflowlevel2",
                 "appointment_uuid": "appointment",
-            }
+            },
+            # "set_fields": {
+            #     "core_user_uuid": "org_core_user_uuids[0]",
+            # },
         },
         "time-log-entry": {
             "validate": False,
@@ -874,33 +878,6 @@ workflowlevel2s = [
         "parent_workflowlevel2": 0,
         "workflowlevel1": 18,
         "type": "c17709b0-3acf-4a93-9d14-a5a5f59fcb77",
-    },
-]
-
-core_users = [
-    {
-        "core_user_uuid": "44852b4a-4e80-448e-8936-71c4c294a1b7",
-        "first_name": "Seed",
-        "last_name": "Data",
-        "email": "",
-        "username": "SeedData",
-        "is_active": True,
-    },
-    {
-        "core_user_uuid": "3418abb1-faff-4f38-86d9-606f3f542ef5",
-        "first_name": "Seed",
-        "last_name": "Data3",
-        "email": "",
-        "username": "SeedData3",
-        "is_active": True,
-    },
-    {
-        "core_user_uuid": "40517e88-26cb-4b34-853f-ed383c1af0d6",
-        "first_name": "Seed",
-        "last_name": "Data2",
-        "email": "",
-        "username": "SeedData2",
-        "is_active": True,
     },
 ]
 


### PR DESCRIPTION
## Purpose
All appointments need to be assigned to all users that will be created at the time the organisation is created.

## Approach
Create a list of the core_users in the seed `Organization` and use its uuids in `set_fields`.

### Further Info
https://humanitec.atlassian.net/browse/CU-803
