### PR TITLE
Set Seed appointments into Org create Week - CU-803

### DIFF
--- a/workflow/seeds/data.py
+++ b/workflow/seeds/data.py
@@ -777,7 +777,10 @@ SEED_DATA = {
                 "siteprofile_uuid": "siteprofiles",
                 "workflowlevel2_uuids": "workflowlevel2",
             },
-            "update_dates": {"start_date": 20, "end_date": 20},
+            "update_dates": {
+                "start_date": "week_of_the_org_created_week",
+                "end_date": "week_of_the_org_created_week"
+            },
             "set_fields": {
                 "invitee_uuids": "org_core_user_uuids",
             }

--- a/workflow/seeds/tests/test_seed.py
+++ b/workflow/seeds/tests/test_seed.py
@@ -1,7 +1,11 @@
+from datetime import date
+from unittest.mock import Mock
+
 import pytest
+from django.utils.dateparse import parse_datetime
 
 from datamesh.models import JoinRecord
-from workflow.seeds.seed import SeedDataMesh
+from workflow.seeds.seed import SeedDataMesh, SeedEnv, SeedLogicModule
 from datamesh.tests.fixtures import org, relationship
 
 
@@ -46,6 +50,37 @@ def test_seed_data_mesh(org, relationship):
         record_uuid="7db2939e-05fd-480a-a375-e1d1575e5af3",
         related_record_uuid="a5e16b81-af04-452e-8478-d3be8ce275f4"
     ).count()
+
+
+@pytest.mark.django_db()
+def test_set_week_of_the_org_created_week(org):
+    org.create_date = date(2019, 8, 14)  # wednesday in week 33
+    org.save()
+    test_data = [
+        {
+            "uuid": "878db099-b8c1-4482-b4a8-11e26168c933",
+            "start_date": "2019-07-30T07:30:00+02:00",  # tuesday in week 31
+            "end_date": "2019-07-31T16:00:00+02:00",
+        },
+        {
+            "uuid": "edeb1722-5b43-4eb0-ae52-b5598e40e704",
+            "start_date": "2019-08-01T07:00:00+02:00",  # thursday in week 31
+        }]
+    seed_env = Mock(SeedEnv)
+    seed_env.organization = org
+    seed_logic_module = SeedLogicModule(seed_env, {})
+    seed_logic_module.set_week_of_the_org_created_week(test_data, "start_date")
+    seed_logic_module.set_week_of_the_org_created_week(test_data, "end_date")
+    new_start_date = parse_datetime(test_data[0]['start_date'])
+    assert new_start_date.isocalendar()[1] == 33
+    assert new_start_date.strftime("%A") == "Tuesday"
+    assert new_start_date.hour == 7
+    assert new_start_date.minute == 30
+    assert new_start_date.tzname() == '+0200'
+    assert test_data[0]['start_date'] == '2019-08-13T07:30:00+02:00'
+    assert test_data[0]['end_date'] == '2019-08-14T16:00:00+02:00'
+    assert test_data[1]['start_date'] == '2019-08-15T07:00:00+02:00'
+
 
 # ToDo:
 # def test_seed_bifrost()


### PR DESCRIPTION
## Purpose
The appointments should start from the week the organisation is created and in total last 4 weeks.

## Approach
Add keyword `week_of_the_org_created_week` in data to trigger a custom function for getting the day in the current week.

### Further Info
https://humanitec.atlassian.net/browse/CU-803