### PR TITLE
Consider changing weeks in Seed appointments - CU-803

### DIFF
--- a/workflow/seeds/seed.py
+++ b/workflow/seeds/seed.py
@@ -198,14 +198,17 @@ class SeedLogicModule(SeedBase):
             return d + delta
 
         monday_of_org = week_start_date(*self.seed_env.organization.create_date.isocalendar()[0:2])
+        min_week = min([parse_datetime(item[date_field_name]).isocalendar()[1] for
+                        item in post_data if date_field_name in item.keys()])  # smallest week number
         for item in post_data:
             if date_field_name not in item.keys():
                 continue
             original_date = parse_datetime(item[date_field_name])
             delta_days = original_date.isoweekday() - 1
+            delta_weeks = original_date.isocalendar()[1] - min_week
             new_datetime = datetime(monday_of_org.year, monday_of_org.month, monday_of_org.day,
                                     original_date.hour, original_date.minute,
-                                    tzinfo=original_date.tzinfo) + timedelta(days=delta_days)
+                                    tzinfo=original_date.tzinfo) + timedelta(days=delta_days + delta_weeks * 7)
             item[date_field_name] = new_datetime.isoformat()
 
     def post_create_requests(self, url, data):

--- a/workflow/seeds/tests/test_seed.py
+++ b/workflow/seeds/tests/test_seed.py
@@ -64,7 +64,7 @@ def test_set_week_of_the_org_created_week(org):
         },
         {
             "uuid": "edeb1722-5b43-4eb0-ae52-b5598e40e704",
-            "start_date": "2019-08-01T07:00:00+02:00",  # thursday in week 31
+            "start_date": "2019-08-08T07:00:00+02:00",  # thursday in week 32
         }]
     seed_env = Mock(SeedEnv)
     seed_env.organization = org
@@ -79,7 +79,8 @@ def test_set_week_of_the_org_created_week(org):
     assert new_start_date.tzname() == '+0200'
     assert test_data[0]['start_date'] == '2019-08-13T07:30:00+02:00'
     assert test_data[0]['end_date'] == '2019-08-14T16:00:00+02:00'
-    assert test_data[1]['start_date'] == '2019-08-15T07:00:00+02:00'
+    assert test_data[1]['start_date'] == '2019-08-22T07:00:00+02:00'
+    assert parse_datetime(test_data[1]['start_date']).isocalendar()[1] == 34
 
 
 # ToDo:


### PR DESCRIPTION
## Purpose
Seeded appointments should keep their distance in time.

## Approach
Calculate the distance in weeks from the minimal week and add that distance to the normalized DateTime.

### Further Info
https://humanitec.atlassian.net/browse/CU-803
