### PR TITLE
Default status on WorkflowLevel2

### DIFF
--- a/workflow/migrations/0016_default_statuslevel.py
+++ b/workflow/migrations/0016_default_statuslevel.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import workflow.models
+
+
+def fill_empty_wfl_status_with_in_progress(apps, schema_editor):
+    """All WFL2 without a status should set to 'in_progress' instead of the default 'project_request'."""
+    wfl_status_model = apps.get_model('workflow', 'WorkflowLevelStatus')
+    wfl_status, _ = wfl_status_model.objects.get_or_create(
+        name="In progress",
+        short_name="in_progress"
+    )
+    wfl2_model = apps.get_model('workflow', 'WorkflowLevel2')
+    db_alias = schema_editor.connection.alias
+    empty_wfl2s = wfl2_model.objects.using(db_alias).filter(status=None)
+    for wfl2 in empty_wfl2s:
+        print(f"Set empty status of WFL2 {wfl2} to 'in_progress'.")
+        wfl2.status = wfl_status
+        wfl2.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('workflow', '0015_auto_20190731_1419'),
+    ]
+
+    operations = [
+
+        migrations.RunPython(fill_empty_wfl_status_with_in_progress,
+                             migrations.RunPython.noop),
+
+        migrations.AlterField(
+            model_name='workflowlevel2',
+            name='status',
+            field=models.ForeignKey(default=workflow.models._get_default_statuslevel, on_delete=django.db.models.deletion.SET_DEFAULT, related_name='workflowlevel2s', to='workflow.WorkflowLevelStatus'),
+        ),
+    ]

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -307,6 +307,14 @@ class WorkflowLevel1(models.Model):
             return self.name
 
 
+def _get_default_statuslevel():
+    wfl_status, _ = WorkflowLevelStatus.objects.get_or_create(
+        name="Project Request",
+        short_name="project_request"
+    )
+    return wfl_status.pk
+
+
 class WorkflowLevel2(models.Model):
     level2_uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, verbose_name='WorkflowLevel2 UUID', help_text="Unique ID")
     description = models.TextField("Description", blank=True, null=True, help_text="Description of the workflow level use")
@@ -322,7 +330,7 @@ class WorkflowLevel2(models.Model):
     start_date = models.DateTimeField("Start Date", null=True, blank=True)
     end_date = models.DateTimeField("End Date", null=True, blank=True)
     type = models.ForeignKey(WorkflowLevelType, null=True, blank=True, on_delete=models.SET_NULL, related_name='workflowlevel2s')
-    status = models.ForeignKey(WorkflowLevelStatus, null=True, blank=True, on_delete=models.SET_NULL, related_name='workflowlevel2s')
+    status = models.ForeignKey(WorkflowLevelStatus, default=_get_default_statuslevel, on_delete=models.SET_DEFAULT, related_name='workflowlevel2s')
 
     class Meta:
         ordering = ('name',)

--- a/workflow/tests/test_workflowlevelstatus.py
+++ b/workflow/tests/test_workflowlevelstatus.py
@@ -3,7 +3,7 @@ from rest_framework.reverse import reverse
 
 import factories
 
-from workflow.models import WorkflowLevelStatus
+from workflow.models import WorkflowLevelStatus, WorkflowLevel2
 from ..views import WorkflowLevelStatusViewSet
 from .fixtures import org_member, org
 
@@ -50,4 +50,10 @@ def test_delete_workflowlevelstatus(request_factory, org_member):
     view = WorkflowLevelStatusViewSet.as_view({'delete': 'destroy'})
     response = view(request, pk=wflstatus.uuid)
     assert response.status_code == 204
-    assert WorkflowLevelStatus.objects.count() == 0
+
+
+@pytest.mark.django_db()
+def test_create_workflowlevel2_with_default_status(request_factory, org_member):
+    wfl1 = factories.WorkflowLevel1()
+    wfl2 = WorkflowLevel2.objects.create(workflowlevel1=wfl1)
+    assert wfl2.status.short_name == 'project_request'


### PR DESCRIPTION
## Purpose
With the new WFL-status-filter all WFLs without any status are hidden.

## Approach
Disable the blank option and add a migration for existing WFLs without a status.

### Further Info
https://humanitec.atlassian.net/browse/CU-735
