### PR TITLE
Add create_date to oauthuser endpoint

### DIFF
--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -114,8 +114,8 @@ class CoreUserSerializer(serializers.ModelSerializer):
         model = wfm.CoreUser
         fields = ('id', 'core_user_uuid', 'first_name', 'last_name', 'email', 'username', 'is_active',
                   'title', 'contact_info', 'privacy_disclaimer_accepted', 'organization', 'core_groups',
-                  'invitation_token')
-        read_only_fields = ('core_user_uuid', 'organization',)
+                  'invitation_token', 'create_date')
+        read_only_fields = ('core_user_uuid', 'organization', 'create_date', )
         depth = 1
 
 

--- a/workflow/tests/test_coreuserview.py
+++ b/workflow/tests/test_coreuserview.py
@@ -403,7 +403,7 @@ class TestResetPassword(object):
 class TestCoreUserRead(object):
 
     keys = {'id', 'core_user_uuid', 'first_name', 'last_name', 'email', 'username', 'is_active', 'title',
-            'contact_info', 'privacy_disclaimer_accepted', 'organization', 'core_groups'}
+            'contact_info', 'privacy_disclaimer_accepted', 'organization', 'core_groups', 'create_date'}
 
     def test_coreuser_list(self, request_factory, org_member):
         factories.CoreUser.create(organization=org_member.organization, username='another_user')  # 2nd user of the org

--- a/workflow/tests/test_serializers.py
+++ b/workflow/tests/test_serializers.py
@@ -67,6 +67,7 @@ def test_core_user_serializer(request_factory, org_member):
             'privacy_disclaimer_accepted',
             'organization',
             'core_groups',
+            'create_date',
             ]
     assert set(data.keys()) == set(keys)
     assert isinstance(data['organization'], dict)


### PR DESCRIPTION
## Purpose
FE needs to know the `create_date` for sending it to external providers, when a User sends a message. 

## Approach
Adds `create_date` to `CoreUserSerializer`.