### PR TITLE
Exclude project_id from WorkflowLevel2Serializer

### DIFF
--- a/workflow/serializers.py
+++ b/workflow/serializers.py
@@ -70,7 +70,8 @@ class WorkflowLevel2Serializer(serializers.ModelSerializer):
 
     class Meta:
         model = wfm.WorkflowLevel2
-        fields = '__all__'
+        # fields = '__all__'
+        exclude = ('project_id', )  # TODO: remove after FE has migrated
 
 
 class UUIDPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):

--- a/workflow/tests/test_serializers.py
+++ b/workflow/tests/test_serializers.py
@@ -94,7 +94,7 @@ def test_workflow_level2_serializer(request_factory, wfl2):
             "type",
             "core_groups",
             "status",
-            "project_id",
+            # "project_id",  # TODO: set back after FE has migrated
             ]
     assert set(data.keys()) == set(keys)
     assert data["id"] == data["level2_uuid"]


### PR DESCRIPTION
## Purpose
The new `project_id` was interfering with the functionality on the FE.

## Approach
Exclude `project_id`-field from the `WorkflowLevel2Serializer`.
