### PR TITLE
Revert "Activate AsyncGateway on root"

### DIFF
--- a/datamesh/tests/test_join.py
+++ b/datamesh/tests/test_join.py
@@ -27,7 +27,7 @@ def test_join_data_one_obj_w_relationships(mock_perform_request, mock_spec, auth
     mock_perform_request.side_effect = [service_response, expand_response]
 
     # make api request
-    path = '/sync/{}/{}/'.format(relationship.origin_model.logic_module_endpoint_name, 'products')
+    path = '/{}/{}/'.format(relationship.origin_model.logic_module_endpoint_name, 'products')
     response = auth_api_client.get(path, {'join': ''})
 
     # validate result
@@ -68,7 +68,7 @@ def test_join_data_one_obj_w_two_relationships(mock_perform_request, mock_spec, 
     mock_perform_request.side_effect = [service_response, expand_response1, expand_response2]
 
     # make api request
-    path = '/sync/{}/{}/'.format(relationship.origin_model.logic_module_endpoint_name, 'products')
+    path = '/{}/{}/'.format(relationship.origin_model.logic_module_endpoint_name, 'products')
     response = auth_api_client.get(path, {'join': ''})
 
     # validate result
@@ -111,7 +111,7 @@ def test_join_data_list(mock_perform_request, mock_spec, auth_api_client, relati
     mock_perform_request.side_effect = [main_service_response] + expand_responses
 
     # make api request
-    path = '/sync/{}/{}/'.format(relationship_with_10_records.origin_model.logic_module_endpoint_name, 'products')
+    path = '/{}/{}/'.format(relationship_with_10_records.origin_model.logic_module_endpoint_name, 'products')
     response = auth_api_client.get(path, {'join': ''})
 
     assert response.status_code == 200

--- a/gateway/tests/test_views.py
+++ b/gateway/tests/test_views.py
@@ -17,7 +17,7 @@ CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 @pytest.mark.django_db()
 @httpretty.activate
 def test_make_service_request_data_and_raw(auth_api_client, logic_module, content, content_type):
-    url = f'/sync/{logic_module.endpoint_name}/thumbnail/1/'
+    url = f'/{logic_module.endpoint_name}/thumbnail/1/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json')) as r:
@@ -48,7 +48,7 @@ def test_make_service_request_data_and_raw(auth_api_client, logic_module, conten
 @httpretty.activate
 def test_make_service_request_to_unexisting_list_endpoint(auth_api_client, logic_module):
 
-    url = f'/sync/{logic_module.endpoint_name}/nowhere/'
+    url = f'/{logic_module.endpoint_name}/nowhere/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json')) as r:
@@ -74,7 +74,7 @@ def test_make_service_request_to_unexisting_list_endpoint(auth_api_client, logic
 @httpretty.activate
 def test_make_service_request_to_unexisting_detail_endpoint(auth_api_client, logic_module):
 
-    url = f'/sync/{logic_module.endpoint_name}/nowhere/123/'
+    url = f'/{logic_module.endpoint_name}/nowhere/123/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json')) as r:
@@ -104,7 +104,7 @@ def test_make_service_request_with_datamesh_detailed(auth_api_client, datamesh):
                          record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
                          related_record_id=1, related_record_uuid=None)
 
-    url = f'/sync/{lm1.endpoint_name}/siteprofiles/19a7f600-74a0-4123-9be5-dfa69aa172cc/'
+    url = f'/{lm1.endpoint_name}/siteprofiles/19a7f600-74a0-4123-9be5-dfa69aa172cc/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json')) as r:
@@ -160,7 +160,7 @@ def test_make_service_request_with_reverse_datamesh_detailed(auth_api_client, da
                          record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
                          related_record_id=1, related_record_uuid=None)
 
-    url = f'/sync/{lm2.endpoint_name}/documents/1/'
+    url = f'/{lm2.endpoint_name}/documents/1/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json')) as r:
@@ -216,7 +216,7 @@ def test_make_service_request_with_datamesh_list(auth_api_client, datamesh):
                          record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
                          related_record_id=1, related_record_uuid=None)
 
-    url = f'/sync/{lm1.endpoint_name}/siteprofiles/'
+    url = f'/{lm1.endpoint_name}/siteprofiles/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json')) as r:

--- a/gateway/tests/test_views_async.py
+++ b/gateway/tests/test_views_async.py
@@ -22,7 +22,7 @@ CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 @patch('gateway.request.aiohttp.ClientSession')
 def test_make_service_request_data_and_raw(client_session_mock, auth_api_client, logic_module, content, content_type,
                                            event_loop):
-    url = f'/{logic_module.endpoint_name}/thumbnail/1/'
+    url = f'/async/{logic_module.endpoint_name}/thumbnail/1/'
 
     # mock aiohttp responses
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
@@ -53,7 +53,7 @@ def test_make_service_request_data_and_raw(client_session_mock, auth_api_client,
 def test_make_service_request_to_unexisting_list_endpoint(client_session_mock, auth_api_client, logic_module,
                                                           event_loop):
 
-    url = f'/{logic_module.endpoint_name}/nowhere/'
+    url = f'/async/{logic_module.endpoint_name}/nowhere/'
 
     # mock aiohttp responses
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
@@ -79,7 +79,7 @@ def test_make_service_request_to_unexisting_list_endpoint(client_session_mock, a
 def test_make_service_request_to_unexisting_detail_endpoint(client_session_mock, auth_api_client, logic_module,
                                                             event_loop):
 
-    url = f'/{logic_module.endpoint_name}/nowhere/123/'
+    url = f'/async/{logic_module.endpoint_name}/nowhere/123/'
 
     # mock aiohttp responses
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_documents.json'), 'rb') as r:
@@ -108,7 +108,7 @@ def test_make_service_request_with_datamesh_detailed(client_session_mock, auth_a
                          record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
                          related_record_id=1, related_record_uuid=None)
 
-    url = f'/{lm1.endpoint_name}/siteprofiles/19a7f600-74a0-4123-9be5-dfa69aa172cc/'
+    url = f'/async/{lm1.endpoint_name}/siteprofiles/19a7f600-74a0-4123-9be5-dfa69aa172cc/'
 
     # mock aiohttp responses
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json'), 'rb') as r:
@@ -152,7 +152,7 @@ def test_make_service_request_with_datamesh_list(client_session_mock, auth_api_c
                          record_id=None, record_uuid='19a7f600-74a0-4123-9be5-dfa69aa172cc',
                          related_record_id=1, related_record_uuid=None)
 
-    url = f'/{lm1.endpoint_name}/siteprofiles/'
+    url = f'/async/{lm1.endpoint_name}/siteprofiles/'
 
     # mock requests
     with open(os.path.join(CURRENT_PATH, 'fixtures/swagger_location.json'), 'rb') as r:

--- a/gateway/urls.py
+++ b/gateway/urls.py
@@ -29,13 +29,13 @@ router.register(r'logicmodule', views.LogicModuleViewSet)
 urlpatterns = [
     re_path(
         rf"^(?!{'|'.join(API_GATEWAY_RESERVED_NAMES)})"  # Reject any of these
-        r"sync/"
+        r"async/"
         r"(?P<service>[^/?#]+)/"  # service (timetracking)
         r"(?P<model>[^/?#]+)/?"  # model (timeevent)
         r"(?:(?P<pk>[^?#/]+)/?)?"  # pk (numeric or UUID)
         r"(?:\?(?P<query>[^#]*))?"  # queryparams (?key1=value1&key2=value2)
         r"(?:#(?P<fragment>.*))?",  # fragment (#some-anchor)
-        views.APIGatewayView.as_view(), name='api-gateway-sync'),
+        views.APIAsyncGatewayView.as_view(), name='api-gateway-async'),
     re_path(
         rf"^(?!{'|'.join(API_GATEWAY_RESERVED_NAMES)})"  # Reject any of these
         r"(?P<service>[^/?#]+)/"  # service (timetracking)
@@ -43,7 +43,7 @@ urlpatterns = [
         r"(?:(?P<pk>[^?#/]+)/?)?"  # pk (numeric or UUID)
         r"(?:\?(?P<query>[^#]*))?"  # queryparams (?key1=value1&key2=value2)
         r"(?:#(?P<fragment>.*))?",  # fragment (#some-anchor)
-        views.APIAsyncGatewayView.as_view(), name='api-gateway'),
+        views.APIGatewayView.as_view(), name='api-gateway'),
     re_path(r'^docs/swagger(?P<format>\.json|\.yaml)$',
             schema_view.without_ui(cache_timeout=0),
             name='schema-swagger-json'),


### PR DESCRIPTION
This reverts commit c88540883f4acaf5e8207888af6965fb16fc821d.

## Purpose
`AsyncGateway` is throwing errors and not yet ready for production.

## Approach
Revert url-change-activation-commit.